### PR TITLE
Fix for errors in crawl_sitemap function

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -16,6 +16,7 @@ from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support.expected_conditions import staleness_of
 from webdriver_manager.chrome import ChromeDriverManager
+from selenium.webdriver.chrome.service import Service as ChromeService
 from urllib.parse import urlparse
 from selenium.webdriver.common.by import By
 
@@ -40,9 +41,11 @@ def extract_links(url: str, timeout: int = 2, install_driver: bool = True):
     webdriver_options.experimental_options['prefs'] = webdriver_prefs
 
     if install_driver:
-        driver = webdriver.Chrome(ChromeDriverManager().install(), options=webdriver_options)
+        service = ChromeService()
+        driver = webdriver.Chrome(service=service, options=webdriver_options)
     else:
         driver = webdriver.Chrome(options=webdriver_options)
+
     driver.get(url)
     try:
         WebDriverWait(driver, timeout).until(staleness_of(driver.find_element(by=By.TAG_NAME, value='html')))

--- a/crawler.py
+++ b/crawler.py
@@ -253,7 +253,7 @@ if __name__ == "__main__":
                                   pdf_driver=args.pdf_driver,
                                   install_chrome_driver=args.install_chrome_driver)
             elif args.crawl_type == 'sitemap':
-                crawl_sitemap(url=args.url,
+                crawl_sitemap(homepage=args.url,
                               crawl_id=args.crawl_id,
                               customer_id=args.customer_id,
                               corpus_id=args.corpus_id,

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ ultimate-sitemap-parser==0.5
 Authlib==1.0.1
 feedparser==6.0.10
 bloom-filter==1.3.3
+selenium==4.9


### PR DESCRIPTION
Hi, wanted to contribute 2 fixes I had to implement to get the crawler.py script running, and are also related to the 2 currently open issues. 

1. Fix for [issue #3](https://github.com/vectara/web-crawler/issues/3) (wrong arg name in call to crawl_sitemap), replaced 'url' with 'homepage'
2. Fix for [issue #4 ](https://github.com/vectara/web-crawler/issues/4), specify selenium version 4.9 in requirements and use service instead of executable_path in selenium webdriver initialization

Can confirm that the crawler.py script runs successfully after implementing these two fixes. 